### PR TITLE
Visual range and escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,6 @@ or:
 let g:defaultWinSwoopHeight = 15
 ```
 
-* Remove or customise the escaped characters on visual mode
-
-    By default, any character that could break a search pattern gets escaped
-
-```
-let g:swoopEscapeChars = "~/\]["
-```
-
-    You can remove the feature by setting it as an empty string.
 
 Tips and Tricks
 ---------------

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ let g:defaultWinSwoopHeight = 15
     By default, any character that could break a search pattern gets escaped
 
 ```
-let g:escapeCharsForVisualSelection = "~/\]["
+let g:swoopEscapeChars = "~/\]["
 ```
 
     You can remove the feature by setting it as an empty string.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ vim swoop
 
 Vim swoop is directly inspired from [helm-swoop](https://github.com/ShingoFukuyama/helm-swoop) we can find as emacs' plugin.
 
-It allows you to find and replace occurences in many buffers being aware of the context.
+It allows you to find and replace occurrences in many buffers being aware of the context.
 
 An animation means more than a boring speech...
 
@@ -23,7 +23,7 @@ When you start vim-swoop (multi or single buffer mode) you get 2 windows.
 First one contain context, the other is the swoop buffer. As you move the cursor to a match, the display windows will show the context.
 
 From the swoop buffer, you can:
-* Interactivly edit your search
+* Interactively edit your search
 * Navigate in results (and context) by moving the cursor
 * Edit and save Swoop Buffer ```:w```.
 *The changes will be repercuted on all files by saving the Swoop Buffer*
@@ -168,6 +168,15 @@ or:
 let g:defaultWinSwoopHeight = 15
 ```
 
+* Remove or customise the escaped characters on visual mode
+
+    By default, any character that could break a search pattern gets escaped
+
+```
+let g:escapeCharsForVisualSelection = "~/\]["
+```
+
+    You can remove the feature by setting it as an empty string.
 
 Tips and Tricks
 ---------------
@@ -224,7 +233,7 @@ Interaction with other plugin or option
     If you need anything else to enchanche compatibility with other plugin, please open an issue.
 
 
-Installation and dependancies
+Installation and dependencies
 -----------------------------
 
 Vim-Swoop is a pure vimscript plugin, no other dependancies.
@@ -241,7 +250,7 @@ Plugin 'pelodelfuego/vim-swoop'
 ```
 
 
-Upcomming feature and improvement
+Upcoming feature and improvement
 -----------------
 
 

--- a/plugin/vim-swoop.vim
+++ b/plugin/vim-swoop.vim
@@ -51,10 +51,6 @@ if !exists('g:defaultWinSwoopHeight')
     let g:defaultWinSwoopHeight = ""
 endif
 
-if !exists('g:swoopEscapeChars')
-    let g:swoopEscapeChars = "~/\]["
-endif
-
 let s:swoopSeparator = "\t"
 
 
@@ -533,11 +529,9 @@ endfunction
 "   =======
 function! s:getVisualSelectionSingleLine()
     let text = getline("'<")[getpos("'<")[2]-1:getpos("'>")[2]-1]
-    if g:swoopEscapeChars == ""
-        return text
-    else
-        return escape(text, g:swoopEscapeChars)
-    endif
+    " escape characters that could throw an error:
+    " E682: Invalid search pattern or delimiter
+    return escape(text, "~/\][")
 endfunction
 
 function! s:convertStringToRegex(rawPattern)

--- a/plugin/vim-swoop.vim
+++ b/plugin/vim-swoop.vim
@@ -1,4 +1,4 @@
-"   Vim Swoop   1.1.5
+"   Vim Swoop   1.1.6
 
 "Copyright (C) 2015 copyright Clément CREPY
 "
@@ -49,6 +49,10 @@ if !exists('g:defaultWinSwoopWidth')
 endif
 if !exists('g:defaultWinSwoopHeight')
     let g:defaultWinSwoopHeight = ""
+endif
+
+if !exists('g:escapeCharsForVisualSelection')
+    let g:escapeCharsForVisualSelection = "~/\]["
 endif
 
 let s:swoopSeparator = "\t"
@@ -528,7 +532,12 @@ endfunction
 "   TOOLBOX
 "   =======
 function! s:getVisualSelectionSingleLine()
-    return getline("'<")[getpos("'<")[2]-1:getpos("'>")[2]]
+    let text = getline("'<")[getpos("'<")[2]-1:getpos("'>")[2]-1]
+    if g:escapeCharsForVisualSelection == ""
+        return text
+    else
+        return escape(text, g:escapeCharsForVisualSelection)
+    endif
 endfunction
 
 function! s:convertStringToRegex(rawPattern)

--- a/plugin/vim-swoop.vim
+++ b/plugin/vim-swoop.vim
@@ -51,8 +51,8 @@ if !exists('g:defaultWinSwoopHeight')
     let g:defaultWinSwoopHeight = ""
 endif
 
-if !exists('g:escapeCharsForVisualSelection')
-    let g:escapeCharsForVisualSelection = "~/\]["
+if !exists('g:swoopEscapeChars')
+    let g:swoopEscapeChars = "~/\]["
 endif
 
 let s:swoopSeparator = "\t"
@@ -533,10 +533,10 @@ endfunction
 "   =======
 function! s:getVisualSelectionSingleLine()
     let text = getline("'<")[getpos("'<")[2]-1:getpos("'>")[2]-1]
-    if g:escapeCharsForVisualSelection == ""
+    if g:swoopEscapeChars == ""
         return text
     else
-        return escape(text, g:escapeCharsForVisualSelection)
+        return escape(text, g:swoopEscapeChars)
     endif
 endfunction
 


### PR DESCRIPTION
Hi @pelodelfuego, I've been using your plugin for the last couple of weeks and it's amazing. Thank you.

I found two small problems when swoop gets started from the visual mode.

First, the text coming from the visual selection includes an extra character. And if the selected text includes slashes or any other pattern character, the plugin throws an error and the results are empty:

[![asciicast](https://asciinema.org/a/f0g0fvcvmrxpt4g7ujt377omf.png)](https://asciinema.org/a/f0g0fvcvmrxpt4g7ujt377omf)

This branch adds an escape option for those characters, transforming the text into a valid search pattern:

[![asciicast](https://asciinema.org/a/ebt4wbtlj0fl5r8wpix35gcad.png)](https://asciinema.org/a/ebt4wbtlj0fl5r8wpix35gcad)

I could be missing some cases, so I made to configurable through `g:swoopEscapeChars`

What do you think?