### PR TITLE
fix for "E937: Attempt to delete a buffer that is in use" on SwoopQuit()

### DIFF
--- a/plugin/vim-swoop.vim
+++ b/plugin/vim-swoop.vim
@@ -569,6 +569,6 @@ augroup swoopAutoCmd
     autocmd!    CursorMovedI   swoopBuf   :call   s:cursorMoved()
 
     autocmd!    BufWrite    swoopBuf    :call   SwoopSave()
-    autocmd!    BufWinLeave   swoopBuf   :call  delete('./swoopBuf')
     autocmd!    BufWinLeave   swoopBuf   :call  SwoopQuit()
+    autocmd!    BufWinLeave   swoopBuf   :call  delete('./swoopBuf')
 augroup END


### PR DESCRIPTION
I think this problem is caused by vim trying to delete the buffer while it's
"locked" cause the file is still there.
This only happens in "higer" versions of vim 7.4 and vim 8.0,
probably due to: https://groups.google.com/forum/#!topic/vim_dev/SpIrI4-0nOw