### PR TITLE
Freeze context when in visual block mode

### DIFF
--- a/plugin/vim-swoop.vim
+++ b/plugin/vim-swoop.vim
@@ -510,7 +510,7 @@ function! s:matchBufferLine(bufferLineList)
 endfunction
 
 function! s:needFreezeContext()
-    if mode() == 'v'
+    if mode() == 'v' || mode() == 'V'
         return 1
     else
         if s:freezeContext == 1


### PR DESCRIPTION
In the swoop buffer it is not possible to select several lines in visual block mode (Ctrl-V). A workaround is 

1. call SwoopFreezeContext()
2. edit the swoop buffer with visual block mode
3. call SwoopUnFreezeContext()

With the change in the pull request the context will be frozen automatically not only in Visual mode but also in Visual block mode. 